### PR TITLE
Altera comunicação do botão Enviar

### DIFF
--- a/css/estilo.css
+++ b/css/estilo.css
@@ -12,6 +12,10 @@ body {
     font-family: 'Open Sans', sans-serif;
 }
 
+button {
+    cursor: pointer;
+}
+
 .login {
     width: 400px;
     margin: 16px auto;
@@ -211,11 +215,11 @@ span[data-acts-as-select]:hover label {
 }
 
 .hover-shadow-box-animation {
-    
+
     vertical-align: middle;
     transform: perspective(1px) translateZ(0);
     box-shadow: 0 0 1px transparent;
-    
+
     transition-duration: 0.3s;
     transition-property: box-shadow, transform;
   }

--- a/popup.html
+++ b/popup.html
@@ -250,7 +250,7 @@
         <textarea id="message" placeholder="Sua mensagem aqui (Não obrigatório)"></textarea>
       </p>
       <p>
-        <div class="button-border"><button type="submit" id="send" value="Send" class="button">Send</button></div>
+        <div class="button-border"><button type="submit" id="send" value="Send" class="button">Enviar</button></div>
       </p>
     </div>
   </div>


### PR DESCRIPTION
O botão de enviar a mensagem estava em inglês, o que não é consistente com a interface que está toda em português. Alterei o texto de "Send" para "Enviar".

Além disso adicionei uma regra css para que a tag <button> tenha o estilo "cursor: pointer", para melhorar a usabilidade da interface.