### PR TITLE
Corrige link do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Mensagem para Whatsapp
 
-Extensão para o Google Chrome, onde você pode enviar uma mensagem para algum contato via WhatsApp sem a necessidade e o trabalho de adiciona-lo na agenda. O resultado é esse aí faça o download e vamos melhorar aos poucos o processo.
+Extensão para o Google Chrome, onde você pode enviar uma mensagem para algum contato via WhatsApp sem a necessidade e o trabalho de adicioná-lo na agenda. O resultado é esse aí faça o download e vamos melhorar aos poucos o processo.
 
-Link da extensão: bit.ly/2S9aWOS 
+## [Baixe a extensão aqui](https://bit.ly/2S9aWOS)
 
 ### NEWS
 
@@ -32,16 +32,16 @@ Tecnologia utilizada para a criação da extensão:
 * Em "Carregar sem compactação" escolha a pasta do projeto.
 * Pronto aparecerá o icone da extensão no cantinho do navegador la em cima na direita.
 
-Obs: Com essa aba aberta onde você carregou o arquivo da extensão baixado, toda modificação no código com seu editor favorito ja é carregado automaticamente na extensão ou va no botão de atualizar na extensão.
+Obs: Com essa aba aberta onde você carregou o arquivo da extensão baixado, toda modificação no código com seu editor favorito ja é carregado automaticamente na extensão ou vá no botão de atualizar na extensão.
 
 ### To Do
 
  - Botão que abrirá campos para adicionar número com ddd e codigo do país + nome da pessoa, criando assim uma agenda no storage.
- - Reconhecer números de qualquer página web e transforma-los em clicaveis levando direto para a tela do whatsapp web.
+ - Reconhecer números de qualquer página web e transformá-los em clicáveis levando direto para a tela do whatsapp web.
  - Implementar bootstrap para estilização
 
- Idéias são bem-vindas
- 
+ Ideias são bem-vindas
+
 ### Development
 
 Hands on!


### PR DESCRIPTION
O link do README para baixar a extensão não estava formatado com hyperlink. Adicionei o hyperlink para facilitar a vida de quem está lendo.
Adicionei pequenas correções ortográficas sem alterar o modelo do
README.